### PR TITLE
README.md: update references/URLs to point to flatcar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# mayday [![Build Status](https://travis-ci.org/coreos/mayday.png?branch=master)](https://travis-ci.org/coreos/mayday)
+# mayday
 
 ...man overboard!
 
@@ -85,7 +85,7 @@ The following information is **never** collected:
 Mayday can be integrated into other projects by defining a default configuration
 file at either the location `/etc/mayday/default.json` or
 `/usr/share/mayday/default.json`. Through the use of [viper](https://github.com/spf13/viper)
-YAML and TOML are now supported as well, though [CoreOS](https://coreos.com)
+YAML and TOML are now supported as well, though [Flatcar Container Linux](https://flatcar-linux.org)
 will continue to use JSON as the mechanism of choice.  If multiple products are
 to be supported specialized configurations can be provided as "profiles" located
 in the above directories (e.g. `/etc/mayday/quay.json`) and the referenced via:
@@ -98,7 +98,7 @@ $ mayday -p quay
 
 The configuration file is comprised of objects (As of 1.0.0 valid objects are
 "files" and "commands").  A example of the syntax can be seen in the file
-[default.json](https://github.com/coreos/mayday/blob/master/default.json).
+[default.json](https://github.com/flatcar-linux/mayday/blob/master/default.json).
 Each top level object contains an array of the relevant items to collect.
 Optionally items can be annotated with a "link" which will provide an easy to
 locate pointer for commonly accessed data.


### PR DESCRIPTION
# Update readme

We were using references to CoreOS in the readme of this repo. This updated the references to Flatcar.

Please note that this PR only covers README; there are more references to CoreOS in other doc files in this repo.

# How to use
* Use the "rich diff" to review doc changes. Use CTRL+f to find occurrences of "core" - should not be present in the patch.

# Testing done
* `gh pr checkout 5` to check out the pr
* `grep -i core README.txt` should return 0 hits. 
