### PR TITLE
default.json: Include current and previous journal

### DIFF
--- a/default.json
+++ b/default.json
@@ -78,6 +78,14 @@
       "link": "free"
     },
     {
+      "args": ["journalctl", "--system", "-b"],
+      "link": "boot.log"
+    },
+    {
+      "args": ["journalctl", "--system", "-b", "-1"],
+      "link": "prev-boot.log"
+    },
+    {
       "args": ["systemctl", "list-units", "-a"],
       "link": "all_units"
     },


### PR DESCRIPTION
The system logs were not gathered by default.
Add the output of journalctl for the current and previous boots, but only
for system messages like the dmesg output and logs of system services
(not user sessions). The journal text output can be large but usually
compresses very well. If there was no previous boot, the dump file in
the tar ball will be empty.

# How to use

```
make
bin/mayday -o t.tar.gz -c default.json # takes some time to compress the system log
```

# Testing done

Check that the tar ball contains files (where the one for the old boot can be empty):

```
less t.tar.gz # check for ↓
-rw-rw-rw- 0/0         6286551 2020-03-30 16:40 202003301640.819488275/mayday_commands/journalctl_--system_-b
l--------- 0/0               0 2020-03-30 16:40 202003301640.819488275/boot.log -> mayday_commands/journalctl_--system_-b
-rw-rw-rw- 0/0               0 2020-03-30 16:40 202003301640.819488275/mayday_commands/journalctl_--system_-b_-1
l--------- 0/0               0 2020-03-30 16:40 202003301640.819488275/boot-prev.log -> mayday_commands/journalctl_--system_-b_-1
```

Check that the content is similar to your `journalctl --system` output:
```
tar -axf t.tar.gz --wildcards '*journalctl*' -O | less # check that the journalctl log was added to the tar ball
```