### PR TITLE
Add directories and gather pstore dumps

### DIFF
--- a/default.json
+++ b/default.json
@@ -13,6 +13,16 @@
       "link": "os-release"
     }
   ],
+  "directories": [
+    {
+      "name": "/sys/fs/pstore",
+      "link": "pstore"
+    },
+    {
+      "name": "/var/lib/systemd/pstore",
+      "link": "pstore-systemd"
+    }
+  ],
   "commands": [
     {
       "args": ["hostname"],

--- a/mayday.go
+++ b/mayday.go
@@ -13,6 +13,7 @@ import (
 	"github.com/coreos/mayday/mayday/plugins/file"
 	"github.com/coreos/mayday/mayday/plugins/journal"
 	"github.com/coreos/mayday/mayday/plugins/rkt"
+	"github.com/coreos/mayday/mayday/plugins/symlink"
 	mtar "github.com/coreos/mayday/mayday/tar"
 	"github.com/coreos/mayday/mayday/tarable"
 
@@ -152,6 +153,10 @@ func main() {
 	for _, d := range C.Directories {
 		log.Printf("reading directory %s\n", d)
 		err := filepath.Walk(d.Name, func(path string, info os.FileInfo, err error) error {
+			if err != nil || info == nil {
+				log.Printf("error opening path %q: %v\n", path, err)
+				return err
+			}
 			if info.Mode().IsRegular() {
 				mf := File{Name: path}
 				df = append(df, mf)
@@ -159,8 +164,9 @@ func main() {
 			return nil
 		})
 
-		if err != nil {
-			log.Printf("error reading path %q: %v\n", d, err)
+		if err == nil {
+			sl := symlink.New(d.Name, d.Link)
+			tarables = append(tarables, sl)
 		}
 	}
 

--- a/mayday/mayday.go
+++ b/mayday/mayday.go
@@ -1,6 +1,7 @@
 package mayday
 
 import (
+	"github.com/coreos/mayday/mayday/plugins/symlink"
 	"github.com/coreos/mayday/mayday/tar"
 	"github.com/coreos/mayday/mayday/tarable"
 )
@@ -8,7 +9,10 @@ import (
 func Run(t tar.Tar, tarables []tarable.Tarable) error {
 
 	for _, tb := range tarables {
-		t.Add(tb)
+		// Skip symlinks which would be added as empty files
+		if _, ok := tb.(*symlink.MaydaySymlink); !ok {
+			t.Add(tb)
+		}
 		t.MaybeMakeLink(tb.Link(), tb.Name())
 	}
 

--- a/mayday/plugins/symlink/symlink.go
+++ b/mayday/plugins/symlink/symlink.go
@@ -1,0 +1,38 @@
+package symlink
+
+import (
+	"archive/tar"
+	"bytes"
+
+	"github.com/coreos/mayday/mayday/tarable"
+)
+
+type MaydaySymlink struct {
+	name string // the name of the file/directory on the filesystem
+	link string // a link to make in the root of the tarball
+}
+
+func New(n string, l string) *MaydaySymlink {
+	f := new(MaydaySymlink)
+	f.name = n
+	f.link = l
+
+	return f
+}
+
+func (f *MaydaySymlink) Content() *bytes.Buffer {
+	return nil
+}
+
+func (f *MaydaySymlink) Header() *tar.Header {
+	var b bytes.Buffer
+	return tarable.Header(&b, f.Name())
+}
+
+func (f *MaydaySymlink) Name() string {
+	return f.name
+}
+
+func (f *MaydaySymlink) Link() string {
+	return f.link
+}

--- a/mayday_test.go
+++ b/mayday_test.go
@@ -20,8 +20,8 @@ const (
   ],
   "directories": [
     {
-      "name": "/var/log",
-      "link": "logs"
+      "name": "/proc/sys/net/ipv4",
+      "link": "ipv4-vars"
     }
   ],
   "commands": [
@@ -54,5 +54,5 @@ func TestConfigStruct(t *testing.T) {
 	assert.EqualValues(t, C.Files[0], File{Name: "/proc/vmstat"})
 	assert.EqualValues(t, C.Files[1], File{Name: "/proc/meminfo", Link: "meminfo"})
 
-	assert.EqualValues(t, C.Directories[0], Directory{Name: "/var/log", Link: "logs"})
+	assert.EqualValues(t, C.Directories[0], Directory{Name: "/proc/sys/net/ipv4", Link: "ipv4-vars"})
 }

--- a/mayday_test.go
+++ b/mayday_test.go
@@ -18,6 +18,12 @@ const (
       "link": "meminfo"
     }
   ],
+  "directories": [
+    {
+      "name": "/var/log",
+      "link": "logs"
+    }
+  ],
   "commands": [
     {
       "args": ["hostname"]
@@ -47,4 +53,6 @@ func TestConfigStruct(t *testing.T) {
 
 	assert.EqualValues(t, C.Files[0], File{Name: "/proc/vmstat"})
 	assert.EqualValues(t, C.Files[1], File{Name: "/proc/meminfo", Link: "meminfo"})
+
+	assert.EqualValues(t, C.Directories[0], Directory{Name: "/var/log", Link: "logs"})
 }


### PR DESCRIPTION
- (Jeff Eklund: https://github.com/coreos/mayday/pull/73) Add possibility to include directory trees in config
    This adds another section, 'directories', to the config files, specifying a
    directory which to recursively traverse and add all normal files found to
    tarables.
    The use case for this is when you want to collect several log files, that may
    have been rotated, for example.
- Run test on a small directory
    The tests should not run on /var/log which can be multiple GBs big.
    Run on /proc/sys/net/ipv4 which is a folder that has only a few small files.
- Collect pstore directories by default    
    Kernel panics will be dumped to the pstore if the system has a pstore backend.
    Collect any pstore dumps by default, both in the pstore sysfs folder as
    in the location where they could be moved by the systemd-pstore cleanup/backup
    service.
- Handle errors for nonexisting directories and create symlinks    
    Non-existing directories resulted in a null-pointer deref causing mayday
    to crash.
    Also, the root symlinks were never created because the directoy specifications
    are turend into file specifications.
    Handle all directory access errors before the nil path string is used to
    open a file.
    Introduce a new type for symlinks that have no content and only serve
    the purpose of creating a directory symlink.


# How to use/Testing done

Trigger a panic on a t1.small from Packet.net with Flatcar installed:

```
$ echo c | sudo tee /proc/sysrq-trigger
```

After it rebooted automatically, copy the new mayday binary:

```
scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null bin/mayday default.json  core@PACKETIP:
```

and run it:

```
ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null core@PACKETIP
# on the host:
sudo ls /sys/fs/pstore # ensure that the pstore dmesg file is there
sudo ./mayday -o out.tar.gz -c default.json
```
Now check that the tar file contains something like `TIMESTAMP/sys/fs/pstore/dmesg-erst-6810039847491731460` which should be the same file as in `/sys/fs/pstore/` on the machine.