### PR TITLE
Log list of coredumps with coredumpctl

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ In addition, more data can be collected by running as the superuser:
 ```
 $ sudo mayday
 ```
+
+If permissions are missing or if a dependency is not installed, the report files
+for that check will be empty. Running as superuser will ensure that all permissions
+are given to access the kernel logs, pstore content, coredump info, and so on.
+
 Even more data can be collected by adding the `--danger` flag:
 
 ```
@@ -66,7 +71,10 @@ collected -- only information that support might need. This includes things like
 
 * network connections, firewall rules, and hostname
 * information about currently running processes, including open files and ports
+* the system journal with the kernel log via `journalctl`, depending on the user this needs `sudo`
+* pstore dmesg logs, normally needs `sudo`
 * log files from systemd services
+* the list of logged coredumps (depends on `systemd-coredump`), works best with `sudo`
 * filesystem and memory usage information
 * information about docker and rkt containers, including network and state but NOT logs
 

--- a/default.json
+++ b/default.json
@@ -96,6 +96,10 @@
       "link": "prev-boot.log"
     },
     {
+      "args": ["coredumpctl", "list"],
+      "link": "coredump-list"
+    },
+    {
       "args": ["systemctl", "list-units", "-a"],
       "link": "all_units"
     },


### PR DESCRIPTION
That a program crashed is not visible in the mayday tar ball unless the
kernel log is searched for it and users may miss that a program crashed.

Include the output of `coredumpctl list` in the tar ball so that the user
can see which programs crashed and whether a core dump is still available
on the machine for further inspection.

# How to use/test

```
make
./bin/mayday -o o.tar.gz -c default.json
tar -axf o.tar.gz --wildcards '*coredumpctl_list*' -O
TIME                            PID   UID   GID SIG COREFILE  EXE
Wed 2020-03-11 14:11:43 CET  3981385  1000  1000   6 missing /your/prog
```
