### PR TITLE
Rename project to github.com/flatcar-linux/mayday

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ before_install:
 install: go get github.com/stretchr/testify
 go:
   - 1.8
-go_import_path: github.com/coreos/mayday
+go_import_path: github.com/flatcar-linux/mayday
 script:
  - ./test
 matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,9 +44,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added network related commands
 - Adding general OS collection commands
 
-[Unreleased]: https://github.com/coreos/mayday/compare/v1.0.0...HEAD
-[1.0.0]:      https://github.com/coreos/mayday/compare/v0.1.0...v1.0.0
-[0.1.0]:      https://github.com/coreos/mayday/compare/455bde42...v0.1.0
+[Unreleased]: https://github.com/flatcar-linux/mayday/compare/v1.0.0...HEAD
+[1.0.0]:      https://github.com/flatcar-linux/mayday/compare/v0.1.0...v1.0.0
+[0.1.0]:      https://github.com/flatcar-linux/mayday/compare/455bde42...v0.1.0
 
 <!--
 > vim:set ts=2 sw=2 expandtab:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,9 @@
 # How to Contribute
 
-CoreOS projects are [Apache 2.0 licensed](LICENSE) and accept contributions via
-GitHub pull requests.  This document outlines some of the conventions on
-development workflow, commit message formatting, contact points and other
-resources to make it easier to get your contribution accepted.
+Flatcar Container Linux projects are [Apache 2.0 licensed](LICENSE) and accept
+contributions via GitHub pull requests.  This document outlines some of the
+conventions on development workflow, commit message formatting, contact points
+and other resources to make it easier to get your contribution accepted.
 
 # Certificate of Origin
 
@@ -14,9 +14,10 @@ contribution. See the [DCO](DCO) file for details.
 
 # Email and Chat
 
-The project currently uses the general CoreOS email list and IRC channel:
-- Email: [coreos-dev](https://groups.google.com/forum/#!forum/coreos-dev)
-- IRC: #[coreos](irc://irc.freenode.org:6667/#coreos) IRC channel on freenode.org
+The project currently uses the general Flatcar Container Linux email list and
+IRC channel:
+- Email: [flatcar-linux-dev](https://groups.google.com/forum/#!forum/flatcar-linux-dev)
+- IRC: #[flatcar](irc://irc.freenode.org:6667/#flatcar) IRC channel on freenode.org
 
 Please avoid emailing maintainers found in the MAINTAINERS file directly. They
 are very busy and read the mailing lists.

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,9 @@
-module github.com/coreos/mayday
+module github.com/flatcar-linux/mayday
 
 go 1.13
 
 require (
+	github.com/BurntSushi/toml v0.3.1 // indirect
 	github.com/coreos/go-systemd v0.0.0-20160621134601-b32b8467dbea
 	github.com/fsnotify/fsnotify v1.4.3-0.20170329110642-4da3e2cfbabc // indirect
 	github.com/godbus/dbus v0.0.0-20151211231602-a1b8ba5163b7
@@ -17,7 +18,6 @@ require (
 	github.com/spf13/pflag v1.0.0
 	github.com/spf13/viper v0.0.0-20170619124313-c1de95864d73
 	github.com/stretchr/testify v1.5.1
-	golang.org/x/crypto v0.0.0-20141219224849-a7ead6ddf062 // indirect
 	golang.org/x/net v0.0.0-20160201052856-d513e58596cd
 	golang.org/x/sys v0.0.0-20170710161658-abf9c25f5445 // indirect
 	golang.org/x/text v0.0.0-20170706130353-cfdf022e86b4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
+github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/coreos/go-systemd v0.0.0-20160621134601-b32b8467dbea h1:00ea7zz/3XXza4AH8qqsZ6e+LhfBVsGgJRMZL4nMSyc=
 github.com/coreos/go-systemd v0.0.0-20160621134601-b32b8467dbea/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
@@ -31,7 +33,6 @@ github.com/spf13/viper v0.0.0-20170619124313-c1de95864d73/go.mod h1:A8kyI5cUJhb8
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
-golang.org/x/crypto v0.0.0-20141219224849-a7ead6ddf062/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/net v0.0.0-20160201052856-d513e58596cd h1:u9YqWFZbNek1vwz2T9UibRb81i9ibZErhrRGrhlQ/Ro=
 golang.org/x/net v0.0.0-20160201052856-d513e58596cd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/sys v0.0.0-20170710161658-abf9c25f5445 h1:ihxcHCoeP6QVHLnvt4PXvpgB9U94enD3OVEM+UcAuVs=
@@ -40,8 +41,7 @@ golang.org/x/text v0.0.0-20170706130353-cfdf022e86b4 h1:LBbuS6bbgvFy6TenhpOngey6
 golang.org/x/text v0.0.0-20170706130353-cfdf022e86b4/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 google.golang.org/grpc v0.0.0-20160225213019-0f80f5b995e8 h1:lIH/bShL4zFLuTh6S9dwHMkr3Kjik7bcafOT3Kh918w=
 google.golang.org/grpc v0.0.0-20160225213019-0f80f5b995e8/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.0.0-20160715033755-e4d366fc3c79 h1:mENkfeXGmLV7lIyBeNdwYWdONek7pH9yHaHMgZyvIWE=
-gopkg.in/yaml.v2 v2.0.0-20160715033755-e4d366fc3c79/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/mayday.go
+++ b/mayday.go
@@ -7,15 +7,15 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/coreos/mayday/mayday"
-	"github.com/coreos/mayday/mayday/plugins/command"
-	"github.com/coreos/mayday/mayday/plugins/docker"
-	"github.com/coreos/mayday/mayday/plugins/file"
-	"github.com/coreos/mayday/mayday/plugins/journal"
-	"github.com/coreos/mayday/mayday/plugins/rkt"
-	"github.com/coreos/mayday/mayday/plugins/symlink"
-	mtar "github.com/coreos/mayday/mayday/tar"
-	"github.com/coreos/mayday/mayday/tarable"
+	"github.com/flatcar-linux/mayday/mayday"
+	"github.com/flatcar-linux/mayday/mayday/plugins/command"
+	"github.com/flatcar-linux/mayday/mayday/plugins/docker"
+	"github.com/flatcar-linux/mayday/mayday/plugins/file"
+	"github.com/flatcar-linux/mayday/mayday/plugins/journal"
+	"github.com/flatcar-linux/mayday/mayday/plugins/rkt"
+	"github.com/flatcar-linux/mayday/mayday/plugins/symlink"
+	mtar "github.com/flatcar-linux/mayday/mayday/tar"
+	"github.com/flatcar-linux/mayday/mayday/tarable"
 
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -90,7 +90,7 @@ func main() {
 	}
 
 	if viper.GetString("config") == configDefault {
-		// CoreOS config location
+		// Flatcar config location
 		viper.AddConfigPath("/usr/share/mayday")
 	}
 

--- a/mayday/mayday.go
+++ b/mayday/mayday.go
@@ -1,9 +1,9 @@
 package mayday
 
 import (
-	"github.com/coreos/mayday/mayday/plugins/symlink"
-	"github.com/coreos/mayday/mayday/tar"
-	"github.com/coreos/mayday/mayday/tarable"
+	"github.com/flatcar-linux/mayday/mayday/plugins/symlink"
+	"github.com/flatcar-linux/mayday/mayday/tar"
+	"github.com/flatcar-linux/mayday/mayday/tarable"
 )
 
 func Run(t tar.Tar, tarables []tarable.Tarable) error {

--- a/mayday/plugins/command/command.go
+++ b/mayday/plugins/command/command.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/coreos/mayday/mayday/tarable"
+	"github.com/flatcar-linux/mayday/mayday/tarable"
 )
 
 const (

--- a/mayday/plugins/docker/docker.go
+++ b/mayday/plugins/docker/docker.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/coreos/mayday/mayday/plugins/command"
+	"github.com/flatcar-linux/mayday/mayday/plugins/command"
 	"github.com/spf13/viper"
 )
 

--- a/mayday/plugins/journal/journal.go
+++ b/mayday/plugins/journal/journal.go
@@ -10,7 +10,7 @@ import (
 	"regexp"
 
 	"github.com/coreos/go-systemd/dbus"
-	"github.com/coreos/mayday/mayday/tarable"
+	"github.com/flatcar-linux/mayday/mayday/tarable"
 )
 
 type SystemdJournal struct {

--- a/mayday/plugins/rkt/rkt.go
+++ b/mayday/plugins/rkt/rkt.go
@@ -5,9 +5,9 @@ import (
 	"bytes"
 	"errors"
 
-	"github.com/coreos/mayday/mayday/plugins/command"
-	"github.com/coreos/mayday/mayday/plugins/rkt/v1alpha"
-	"github.com/coreos/mayday/mayday/tarable"
+	"github.com/flatcar-linux/mayday/mayday/plugins/command"
+	"github.com/flatcar-linux/mayday/mayday/plugins/rkt/v1alpha"
+	"github.com/flatcar-linux/mayday/mayday/tarable"
 	"github.com/spf13/viper"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"

--- a/mayday/plugins/rkt/rkt_test.go
+++ b/mayday/plugins/rkt/rkt_test.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/coreos/mayday/mayday/plugins/rkt/v1alpha"
+	"github.com/flatcar-linux/mayday/mayday/plugins/rkt/v1alpha"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 )

--- a/mayday/plugins/symlink/symlink.go
+++ b/mayday/plugins/symlink/symlink.go
@@ -4,7 +4,7 @@ import (
 	"archive/tar"
 	"bytes"
 
-	"github.com/coreos/mayday/mayday/tarable"
+	"github.com/flatcar-linux/mayday/mayday/tarable"
 )
 
 type MaydaySymlink struct {

--- a/mayday/tar/tar.go
+++ b/mayday/tar/tar.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/coreos/mayday/mayday/tarable"
+	"github.com/flatcar-linux/mayday/mayday/tarable"
 )
 
 type Tar struct {

--- a/test
+++ b/test
@@ -14,14 +14,14 @@ echo "Running tests..."
 if [[ $* == *--cover* ]]; then
 	# generate html cover document
 	mkdir -p tmp/
-	go test github.com/coreos/mayday -coverprofile tmp/main.out
-	go test github.com/coreos/mayday/mayday -coverprofile tmp/mayday.out
+	go test github.com/flatcar-linux/mayday -coverprofile tmp/main.out
+	go test github.com/flatcar-linux/mayday/mayday -coverprofile tmp/mayday.out
 	go tool cover -html=tmp/mayday.out -o tmp/mayday.html
 	go tool cover -html=tmp/main.out -o tmp/main.html
 
 	for PLUGIN in "command" "docker" "file" "journal" "rkt"
 	do
-		go test github.com/coreos/mayday/mayday/plugins/$PLUGIN -coverprofile tmp/$PLUGIN.out
+		go test github.com/flatcar-linux/mayday/mayday/plugins/$PLUGIN -coverprofile tmp/$PLUGIN.out
 		go tool cover -html=tmp/$PLUGIN.out -o tmp/$PLUGIN.html
 	done
 


### PR DESCRIPTION
This PR renames the project and replaces some coreos stuff with flatcar ones (mailing lists, etc).

Not everything was replaced. MAINTAINERS file is left intact. Maybe we should just drop the file. Code of conduct file is also left untouched.


# How to use

Try to build it.


# Testing done

Built the code and run the tests. Checked the occurrences of coreos with `git grep -nie coreos`.
