### PR TITLE
Update branch references from 'flatcar-master' to 'main' in workflow …

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -4,9 +4,9 @@ name: Go
 
 on:
   push:
-    branches: [ "flatcar-master" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "flatcar-master" ]
+    branches: [ "main" ]
 
 jobs:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ are very busy and read the mailing lists.
 
 This is a rough outline of what a contributor's workflow looks like:
 
-- Create a topic branch from where you want to base your work (usually master).
+- Create a topic branch from where you want to base your work (usually main).
 - Make commits of logical units.
 - Make sure your commit messages are in the proper format (see below).
 - Push your changes to a topic branch in your fork of the repository.

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ $ mayday -p quay
 
 The configuration file is comprised of objects (As of 1.0.0 valid objects are
 "files" and "commands").  A example of the syntax can be seen in the file
-[default.json](https://github.com/flatcar/mayday/blob/master/default.json).
+[default.json](https://github.com/flatcar/mayday/blob/main/default.json).
 Each top level object contains an array of the relevant items to collect.
 Optionally items can be annotated with a "link" which will provide an easy to
 locate pointer for commonly accessed data.


### PR DESCRIPTION
This PR updates default branch references from "master" and "flatcar-master" to "main" to align with modern Git conventions and inclusive naming practices.

This pull request updates branch references across multiple files to replace "flatcar-master" and "master" with "main" for consistency with modern branch naming conventions.

### Branch reference updates:

* [`.github/workflows/go.yml`](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fL7-R9): Updated branch references in the `push` and `pull_request` triggers from "flatcar-master" to "main".
* [`CONTRIBUTING.md`](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L35-R35): Replaced "master" with "main" in the instructions for creating a topic branch.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L120-R120): Updated the link to the `default.json` file to use "main" instead of "master" in the URL.

In reference to https://github.com/flatcar/Flatcar/issues/1714