### PR TITLE
Add CODEOWNERS file for automated reviewer assignment

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,5 @@
+# CODEOWNERS file for mayday
+# This file defines who is responsible for code review
+# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+* @flatcar/flatcar-maintainers


### PR DESCRIPTION
This PR adds a CODEOWNERS file to automatically assign the appropriate maintainer team for pull request reviews, addressing the manual reviewer assignment issues outlined in https://github.com/flatcar/Flatcar/issues/1791.